### PR TITLE
Configurable log file location support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -29,7 +29,8 @@
       "Bash(powershell \"Get-ChildItem -Path . -Recurse -Filter *.log -ErrorAction SilentlyContinue | Where-Object {$_LastWriteTime -gt \\(Get-Date\\).AddMinutes\\(-1\\)} | Select-Object FullName\")",
       "Bash(powershell \"Get-ChildItem -Path . -Recurse -Filter *.log -ErrorAction SilentlyContinue | Select-Object FullName, LastWriteTime | Where-Object {$_astWriteTime -gt \\(Get-Date\\).AddMinutes\\(-1\\)} | Format-Table -AutoSize\")",
       "Bash(powershell \"Get-Process | Where-Object {$_rocessName -like ''*DynamicBackground*''} | Select-Object ProcessName, Id | Format-Table -AutoSize\")",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "Bash(more:*)"
     ]
   }
 }

--- a/DynamicBackground/Infrastructure/AppBootstrapper.cs
+++ b/DynamicBackground/Infrastructure/AppBootstrapper.cs
@@ -23,11 +23,15 @@ namespace DynamicBackground.Infrastructure
                 AppConstants.APP_FOLDER_NAME,
                 AppConstants.SETTINGS_FILE_NAME);
 
-            // Register logging service
-            var logFilePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                AppConstants.APP_FOLDER_NAME,
-                AppConstants.LOG_FILE_NAME);
+            // Register log file manager
+            services.AddSingleton<ILogFileManager, LogFileManager>();
+
+            // Register logging service with configurable log file location
+            var logFileManager = new LogFileManager(new SettingsService(
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    AppConstants.APP_FOLDER_NAME,
+                    AppConstants.SETTINGS_FILE_NAME)));
+            var logFilePath = logFileManager.GetLogFilePath();
             services.AddSingleton<ILogger>(new DualModeLogger(logFilePath));
 
             // Register core services

--- a/DynamicBackground/Infrastructure/AppConstants.cs
+++ b/DynamicBackground/Infrastructure/AppConstants.cs
@@ -7,6 +7,7 @@ namespace DynamicBackground.Infrastructure
     {
         // Settings Keys
         public const string SETTINGS_KEY_IMAGE_SAVE_LOCATION = "ImgSaveLoc";
+        public const string SETTINGS_KEY_LOG_FILE_LOCATION = "LogLoc";
         public const string SETTINGS_KEY_UPDATE_INTERVAL = "Interval";
         public const string SETTINGS_KEY_STARTUP_DELAY = "StartupDelay";
 

--- a/DynamicBackground/Services/Abstractions/ILogFileManager.cs
+++ b/DynamicBackground/Services/Abstractions/ILogFileManager.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace DynamicBackground.Services.Abstractions
+{
+    /// <summary>
+    /// Interface for managing log file paths with configurable location.
+    /// </summary>
+    public interface ILogFileManager
+    {
+        /// <summary>
+        /// Gets the current log file path based on settings or default.
+        /// </summary>
+        string GetLogFilePath();
+
+        /// <summary>
+        /// Sets the log file location. Can be a directory or full file path.
+        /// </summary>
+        void SetLogFilePath(string path);
+
+        /// <summary>
+        /// Gets the current log file directory.
+        /// </summary>
+        string GetLogDirectory();
+
+        /// <summary>
+        /// Ensures the log file directory exists.
+        /// </summary>
+        void EnsureLogDirectory();
+    }
+}

--- a/DynamicBackground/Services/LogFileManager.cs
+++ b/DynamicBackground/Services/LogFileManager.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using DynamicBackground.Services.Abstractions;
+using DynamicBackground.Infrastructure;
+
+namespace DynamicBackground.Services
+{
+    /// <summary>
+    /// Service for managing log file paths with configurable location.
+    /// Defaults to application running directory but can be configured through settings.
+    /// </summary>
+    public class LogFileManager : ILogFileManager
+    {
+        private readonly ISettingsService _settingsService;
+        private readonly string _defaultLogFilePath;
+        private readonly string _logFileName;
+
+        public LogFileManager(ISettingsService settingsService, string logFileName = AppConstants.LOG_FILE_NAME)
+        {
+            _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+            _logFileName = logFileName;
+            _defaultLogFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, logFileName);
+        }
+
+        /// <summary>
+        /// Gets the current log file path based on settings or default.
+        /// </summary>
+        public string GetLogFilePath()
+        {
+            try
+            {
+                var configuredPath = _settingsService.GetSetting(AppConstants.SETTINGS_KEY_LOG_FILE_LOCATION);
+
+                if (!string.IsNullOrEmpty(configuredPath))
+                {
+                    // If path is a directory, append the log file name
+                    if (Directory.Exists(configuredPath))
+                    {
+                        return Path.Combine(configuredPath, _logFileName);
+                    }
+
+                    // If path is a full file path, use it directly
+                    if (Path.GetFileName(configuredPath) == _logFileName)
+                    {
+                        return configuredPath;
+                    }
+
+                    // If path is a directory without trailing separator, append log file name
+                    if (Path.GetDirectoryName(configuredPath) == configuredPath)
+                    {
+                        return Path.Combine(configuredPath, _logFileName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error getting log file location from settings: {ex}");
+            }
+
+            return _defaultLogFilePath;
+        }
+
+        /// <summary>
+        /// Sets the log file location. Can be a directory or full file path.
+        /// </summary>
+        public void SetLogFilePath(string path)
+        {
+            try
+            {
+                // Validate the path
+                if (string.IsNullOrEmpty(path))
+                {
+                    throw new ArgumentException("Log file path cannot be empty", nameof(path));
+                }
+
+                // If path is a directory, ensure it exists
+                if (Directory.Exists(path))
+                {
+                    _settingsService.SetSetting(AppConstants.SETTINGS_KEY_LOG_FILE_LOCATION, path);
+                    return;
+                }
+
+                // If path is a file, validate it's in a valid directory
+                var directory = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+                {
+                    _settingsService.SetSetting(AppConstants.SETTINGS_KEY_LOG_FILE_LOCATION, path);
+                    return;
+                }
+
+                throw new DirectoryNotFoundException($"Log file directory does not exist: {directory}");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error setting log file location: {ex}");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Gets the current log file directory.
+        /// </summary>
+        public string GetLogDirectory()
+        {
+            return Path.GetDirectoryName(GetLogFilePath()) ?? _defaultLogFilePath;
+        }
+
+        /// <summary>
+        /// Ensures the log file directory exists.
+        /// </summary>
+        public void EnsureLogDirectory()
+        {
+            try
+            {
+                var directory = GetLogDirectory();
+                if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error creating log directory: {ex}");
+            }
+        }
+    }
+}

--- a/DynamicBackground/Services/SettingsService.cs
+++ b/DynamicBackground/Services/SettingsService.cs
@@ -125,7 +125,8 @@ namespace DynamicBackground.Services
                             Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
                             "Bing Backgrounds", DateTime.Now.Year.ToString()) },
                         { "Interval", "720" },
-                        { AppConstants.SETTINGS_KEY_STARTUP_DELAY, AppConstants.DEFAULT_STARTUP_DELAY_SECONDS.ToString() }
+                        { AppConstants.SETTINGS_KEY_STARTUP_DELAY, AppConstants.DEFAULT_STARTUP_DELAY_SECONDS.ToString() },
+                        { AppConstants.SETTINGS_KEY_LOG_FILE_LOCATION, AppDomain.CurrentDomain.BaseDirectory }
                     };
                     SaveSettings(defaults);
                 }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ DynamicBackground is a **production-ready**, **cross-platform wallpaper manageme
 - **Error Handling:** Comprehensive error reporting and logging
 - **Async Operations:** Non-blocking UI with proper async/await patterns
 - **Production-Ready:** 86 tests passing, 85%+ code coverage, no build errors
+- **Configurable Log Location:** Application directory by default, configurable through settings
 
 ---
 
@@ -680,6 +681,7 @@ For comprehensive project documentation and analysis, refer to these consolidate
 - **[COMPLETE MODERNIZATION FINAL REPORT](COMPLETE_MODERNIZATION_FINAL_REPORT.md)** - Comprehensive final report covering the entire modernization project
 - **[MASTER ANALYSIS CONSOLIDATED](MASTER_ANALYSIS_CONSOLIDATED.md)** - Original analysis and strategic planning documentation
 - **[PHASES 2-3-4 IMPLEMENTATION REPORT](PHASES_2_3_4_IMPLEMENTATION_REPORT.md)** - Detailed technical breakdown of implementation phases
+- **[LOG CONFIGURATION UPDATE](Reports/UiUpgrade.md)** - Recent update for configurable log file location
 
 ---
 


### PR DESCRIPTION
Add ILogFileManager and LogFileManager to enable user-configurable log file paths, defaulting to the app directory. Update AppConstants and SettingsService to support the new setting. Refactor AppBootstrapper to use LogFileManager for logger initialization. Update README and settings.local.json to document and support the new feature.